### PR TITLE
Added Transactional to Runner

### DIFF
--- a/trackservice/src/main/java/com/expeditors/trackservice/TrackserviceApplication.java
+++ b/trackservice/src/main/java/com/expeditors/trackservice/TrackserviceApplication.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.expeditors.trackservice.config.profiles.Profiles.H2;
 
@@ -43,6 +44,7 @@ class Runner implements CommandLineRunner{
     }
 
     @Override
+    @Transactional
     public void run(String... args) throws Exception {
 
         var dateList = List.of(
@@ -76,5 +78,11 @@ class Runner implements CommandLineRunner{
 
 //        artistList.forEach(artistService::addEntity);
         trackList.forEach(trackService::addEntity);
+
+        List<Track> tracks = trackService.getAllEntities();
+        for(Track track : tracks) {
+            System.out.println("album: " + track.getAlbum() + ", title: " + track.getTitle()
+            + ", type: " + track.getType());
+        }
     }
 }

--- a/trackservice/src/test/java/com/expeditors/trackservice/repository/jpa/TrackJpaRepositoryAdapterTest.java
+++ b/trackservice/src/test/java/com/expeditors/trackservice/repository/jpa/TrackJpaRepositoryAdapterTest.java
@@ -15,12 +15,14 @@ import java.util.Set;
 
 import static com.expeditors.trackservice.config.profiles.Profiles.H2;
 import static com.expeditors.trackservice.config.profiles.Profiles.JPA;
+import static com.expeditors.trackservice.config.profiles.Profiles.POSTGRE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 @SpringBootTest(webEnvironment = NONE)
-@ActiveProfiles(profiles = {JPA, H2})
+//@ActiveProfiles(profiles = {JPA, H2})
+@ActiveProfiles(profiles = {JPA, POSTGRE})
 public class TrackJpaRepositoryAdapterTest {
 
     @Autowired


### PR DESCRIPTION
First of all, the fix is simple, add an @Transactional to your 'run' method in the Runner.

The error was happening because of the last Track you were adding, where you were adding track id 4 more than once.  It would have been persisted the first you added it.  The next time you tried to add it, Hibernate would see that it had an id that was not one, but, since there is no persistence context without the Transaction, it will not find it in there and give the error about a "detached" entity.

With the @Transaction, the persistence context will be there for the duration of the method, so the next time hibernate sees the same artist, it will find it in the persistence context and be happy.

One way to see what is happening is to put a break in the for loop i have created in your Runner.  If you examine each track after it has been persisted, you will notice that is has an id, and the Tracks persisted with it also have an id.  

Let me know if this does/does not make sense.